### PR TITLE
Fix discord links

### DIFF
--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -76,7 +76,7 @@ Tendremos más de 30 transmisiones en inglés, además de transmisiones en espa�
 
 Si necesitas ayuda adicional con tus proyectos, puedes unirte a las Horas de Oficina en nuestro Discord.
 
-[![Azure AI Discord](https://dcbadge.limes.pink/api/server/kzRShWzttr)](https://discord.gg/X7C7UxCFSY)
+[![Azure AI Discord](https://dcbadge.limes.pink/api/server/kzRShWzttr)](https://discord.gg/ZkEG5GYfGU)
 
 Al momento, este es el horario:
 
@@ -91,4 +91,4 @@ Al momento, este es el horario:
 
 Únete a [TheSource EHub](https://aka.ms/thesource/ai_agents) para explorar nuestras mejores selecciones de capacitaciones, transmisiones en vivo, repositorios, guías técnicas, blogs, descargas, certificaciones y más, todo actualizado mensualmente. La sección de Agentes de IA ofrece recursos esenciales para crear Agentes de IA, mientras que otras secciones brindan información sobre IA, herramientas de desarrollo y lenguajes de programación.
 
-También puedes publicar preguntas en nuestro [foro de discusión](https://github.com/microsoft/AI_Agents_Hackathon/discussions), o chatear con otros participantes en el [Discord](https://discord.gg/X7C7UxCFSY).
+También puedes publicar preguntas en nuestro [foro de discusión](https://github.com/microsoft/AI_Agents_Hackathon/discussions), o chatear con otros participantes en el [Discord](https://discord.gg/ZkEG5GYfGU).

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,7 +132,7 @@ See our Chinese sessions on [the Chinese landing page](zh/).
 
 For additional help with your hacks, you can drop by Office Hours in our AI Discord channel.
 
-[![Azure AI Discord](https://dcbadge.limes.pink/api/server/kzRShWzttr)](https://discord.gg/X7C7UxCFSY)
+[![Azure AI Discord](https://dcbadge.limes.pink/api/server/kzRShWzttr)](https://discord.gg/ZkEG5GYfGU)
 
 Here are the Office Hours scheduled so far:
 
@@ -157,7 +157,7 @@ To find more samples, check out the following resources:
 
 Join [TheSource EHub](https://aka.ms/thesource/ai_agents) to explore top picks including trainings, livestreams, repositories, technical guides, blogs, downloads, certifications, and more, all updated monthly. The AI Agent section offers essential resources for creating AI Agents, while other sections provide insights into AI, development tools, and programming languages.
 
-You can also post questions in our [discussions forum](https://github.com/microsoft/AI_Agents_Hackathon/discussions), or chat with attendees in the [Discord channel](https://discord.gg/X7C7UxCFSY).
+You can also post questions in our [discussions forum](https://github.com/microsoft/AI_Agents_Hackathon/discussions), or chat with attendees in the [Discord channel](https://discord.gg/ZkEG5GYfGU).
 
 <!--## Judging
 

--- a/docs/pt/index.md
+++ b/docs/pt/index.md
@@ -71,7 +71,7 @@ Teremos mais de 30 transmissões em inglês, além de transmissões em espanhol 
 
 Precisa de ajuda com seu projeto? Participe do Horário de Suporte Técnico no canal de Discord de IA e receba orientação de especialistas! 🚀
 
-[![Azure AI Discord](https://dcbadge.limes.pink/api/server/kzRShWzttr)](https://discord.gg/X7C7UxCFSY)
+[![Azure AI Discord](https://dcbadge.limes.pink/api/server/kzRShWzttr)](https://discord.gg/ZkEG5GYfGU)
 
 Aqui estão os horários de atendimento já agendados:
 
@@ -86,4 +86,4 @@ Aqui estão os horários de atendimento já agendados:
 
 Junte-se ao [TheSource EHub](https://aka.ms/thesource/ai_agents) para explorar os principais recursos, incluindo treinamentos, transmissões ao vivo, repositórios, guias técnicos, blogs, downloads, certificações e muito mais, atualizados mensalmente. A seção de Agentes de IA oferece recursos essenciais para criar agentes de IA, enquanto outras seções fornecem insights sobre IA, ferramentas de desenvolvimento e linguagens de programação.
 
-Você também pode postar perguntas em nosso [fórum de discussões](https://github.com/microsoft/AI_Agents_Hackathon/discussions) ou conversar com outros participantes no [canal do Discord](https://discord.gg/X7C7UxCFSY).
+Você também pode postar perguntas em nosso [fórum de discussões](https://github.com/microsoft/AI_Agents_Hackathon/discussions) ou conversar com outros participantes no [canal do Discord](https://discord.gg/ZkEG5GYfGU).

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -69,7 +69,7 @@ hide:
 
 如果您需要更多帮助，可以在我们的AI Discord频道参加办公时间。
 
-[![Azure AI Discord](https://dcbadge.limes.pink/api/server/kzRShWzttr)](https://discord.gg/X7C7UxCFSY)
+[![Azure AI Discord](https://dcbadge.limes.pink/api/server/kzRShWzttr)](https://discord.gg/ZkEG5GYfGU)
 
 以下是目前安排的办公时间：
 
@@ -84,7 +84,7 @@ hide:
 
 加入 [TheSource EHub](https://aka.ms/thesource/ai_agents)，探索精选资源，包括培训、直播、代码库、技术指南、博客、下载、认证等，每月更新。AI代理部分提供创建AI代理的关键资源，其他部分则涵盖AI、开发工具和编程语言的见解。
 
-您也可以在我们的[讨论论坛](https://github.com/microsoft/AI_Agents_Hackathon/discussions)中提问，或在[Discord频道](https://discord.gg/X7C7UxCFSY)与其他参与者交流。
+您也可以在我们的[讨论论坛](https://github.com/microsoft/AI_Agents_Hackathon/discussions)中提问，或在[Discord频道](https://discord.gg/ZkEG5GYfGU)与其他参与者交流。
 
 
 **免责声明**：  


### PR DESCRIPTION
The current one is expired, this one should never expire, and is for the ai-agents-hackathon channel. FYI @mbaiza27 